### PR TITLE
Use the v2 PagerDuty API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then add **hubot-at-oncall** to your `external-scripts.json`:
 ## Sample Interactions
 
 ```
-malcom>> There appears to be something wrong with the engine. @oncall
+malcolm>> There appears to be something wrong with the engine. @oncall
 hubot>> @kaylee ^^^^
 kaylee>> Not to fret Cap'n. I'm on it.
 ```


### PR DESCRIPTION
The v2 API gives us an `/oncalls` endpoint which makes this script much easier.

- Adds an accept header that specifically requests the v2 API.
- Adds an environment variable to specify which escalation policies to use (defaulting to `Default`).

/cc @carylee @bensongit @downie 